### PR TITLE
Support deb components other than `main`

### DIFF
--- a/debian_packages/private/lockfile_generator/config.py
+++ b/debian_packages/private/lockfile_generator/config.py
@@ -43,6 +43,7 @@ class PackagesConfig(YAMLWizard):
     archs: list[Arch]
     distros: list[Distro]
     packages: list[str]
+    components: list[str] = field(default_factory=lambda: ["main"])
     exclude_packages: list[str] = field(default_factory=list)
     package_priorities: list[list[str]] = field(default_factory=list)
 

--- a/debian_packages/private/lockfile_generator/lockfile.py
+++ b/debian_packages/private/lockfile_generator/lockfile.py
@@ -40,6 +40,7 @@ def generate_lockfile(
                     distro=distro,
                     arch=arch,
                     mirror=mirror,
+                    components=pc.components,
                 )
             pig = pigs[(distro, arch)]
             for package_name in pc.packages:

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -84,3 +84,15 @@ debian_packages_lockfile(
     packages_file = "ubuntu-packages.yaml",
     snapshots_file = "ubuntu-snapshots.yaml",
 )
+
+# Generate lockfile with:
+# bazel run :ubuntu_packages_universe.generate
+# Update snapshots with:
+# bazel run :ubuntu_packages_universe.update
+debian_packages_lockfile(
+    name = "ubuntu_packages_universe",
+    lock_file = "ubuntu-packages-universe.lock",
+    mirror = "https://snapshot.ubuntu.com",
+    packages_file = "ubuntu-packages-universe.yaml",
+    snapshots_file = "ubuntu-snapshots.yaml",
+)

--- a/e2e/smoke/ubuntu-packages-universe.lock
+++ b/e2e/smoke/ubuntu-packages-universe.lock
@@ -1,0 +1,53 @@
+{
+  "files": {
+    "ubuntu2204": {
+      "amd64": [
+        {
+          "name": "fonts_dejavu",
+          "sha256": "83e43fdb9248647fd5dbcb797cead127f2bc80a992312795be42b0b365907dd5",
+          "url": "https://snapshot.ubuntu.com/ubuntu/20240223T000000Z/pool/universe/f/fonts-dejavu/fonts-dejavu_2.37-2build1_all.deb",
+          "version": "2.37-2build1"
+        },
+        {
+          "name": "fonts_dejavu_core",
+          "sha256": "c33fe8bf33b50d99d6448804a090123b1bbba37d7a8703c630695676d110a47d",
+          "url": "https://snapshot.ubuntu.com/ubuntu/20240223T000000Z/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-2build1_all.deb",
+          "version": "2.37-2build1"
+        },
+        {
+          "name": "fonts_dejavu_extra",
+          "sha256": "82ac55cdab01af5c2d21b0af9abf8c9fc638f989a1ff3eddd1490b294bd9be6b",
+          "url": "https://snapshot.ubuntu.com/ubuntu/20240223T000000Z/pool/main/f/fonts-dejavu/fonts-dejavu-extra_2.37-2build1_all.deb",
+          "version": "2.37-2build1"
+        },
+        {
+          "name": "libasound2",
+          "sha256": "4543d27252b0caa67222287adc76988ecd86a4ff6d7a69cfd5343d21aa1ddb02",
+          "url": "https://snapshot.ubuntu.com/ubuntu/20240223T000000Z/pool/universe/o/oss4/liboss4-salsa-asound2_4.2-build2010-5ubuntu9_amd64.deb",
+          "version": null
+        }
+      ]
+    }
+  },
+  "packages": {
+    "ubuntu2204": {
+      "amd64": [
+        {
+          "dependencies": [
+            "fonts_dejavu_core",
+            "fonts_dejavu_extra"
+          ],
+          "name": "fonts_dejavu"
+        },
+        {
+          "dependencies": [],
+          "name": "libasound2"
+        }
+      ]
+    }
+  },
+  "snapshots": {
+    "main": "20240223T000000Z",
+    "security": "20240223T000000Z"
+  }
+}

--- a/e2e/smoke/ubuntu-packages-universe.yaml
+++ b/e2e/smoke/ubuntu-packages-universe.yaml
@@ -1,0 +1,6 @@
+- distros: ["ubuntu2204"]
+  archs: ["amd64"]
+  components: ["main", "universe"]
+  packages:
+    - fonts-dejavu  # A metapackage in universe, with two dependencies in main (fonts-dejavu-core & fonts-dejavu-extra)
+    - libasound2    # A package in main, that is "provided by" a package in universe (liboss4-salsa-asound2)


### PR DESCRIPTION
Hi @betaboon!
I was looking into the recently added support for Ubuntu in #43 and realized that restricting only to the [`main` component](https://help.ubuntu.com/community/Repositories#Components) can be restrictive for some packages, especially when some dependencies exist across components (see added smoke test).
This PR adds support for other user-specified components (e.g. `restricted`, `universe`, `multiverse` for Ubuntu) via a new `components` field in the `packages.yaml`. It is backwards compatible as we default to `main` only as we implicitly did previously.

I have not tested this on anything but Ubuntu 22.04, but it should also work for Debian components like `contrib`, `non-free`, etc...