### PR TITLE
[WIP][Experiment] Allow custom sourcing

### DIFF
--- a/debian_packages/private/lockfile.bzl
+++ b/debian_packages/private/lockfile.bzl
@@ -8,6 +8,7 @@ def debian_packages_lockfile(
         packages_file = "packages.yaml",
         lock_file = "packages.lock",
         mirror = "https://snapshot.debian.org",
+        exact_sources = [],
         verbose = False,
         debug = False):
     """Macro that produces targets to interact with a lockfile.
@@ -43,6 +44,7 @@ def debian_packages_lockfile(
       packages_file: The file to read the desired packages from.
       lock_file: The file to write locked packages to.
       mirror: The debian-snapshot host to use.
+      exact_sources: a list of sources from which to read. Incompatible with mirror, snapshots_file
       verbose: Enable verbose logging.
       debug: Enable debug logging.
     """
@@ -57,15 +59,17 @@ def debian_packages_lockfile(
 
     args = [
         "$(location {})".format(lockfile_generator),
-        "--snapshots-file $(rootpath {})".format(snapshots_file),
         "--packages-file $(rootpath {})".format(packages_file),
         "--lock-file $(rootpath {})".format(lock_file),
-        "--mirror {}".format(mirror),
     ]
-
+    if exact_sources:
+        args.append("--exact-sources {}".format(" ".join(exact_sources)))
+    if snapshots_file:
+        args.append("--snapshots-file $(rootpath {})".format(snapshots_file))
+    if mirror:
+        args.append("--mirror {}".format(mirror))
     if verbose:
         args.append("--verbose")
-
     if debug:
         args.append("--debug")
 

--- a/debian_packages/private/lockfile.bzl
+++ b/debian_packages/private/lockfile.bzl
@@ -7,7 +7,7 @@ def debian_packages_lockfile(
         snapshots_file = "",
         packages_file = "packages.yaml",
         lock_file = "packages.lock",
-        mirror = "https://snapshot.debian.org",
+        mirror = "",
         exact_sources = [],
         verbose = False,
         debug = False):

--- a/debian_packages/private/lockfile.bzl
+++ b/debian_packages/private/lockfile.bzl
@@ -4,7 +4,7 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 def debian_packages_lockfile(
         name,
-        snapshots_file = "snapshots.yaml",
+        snapshots_file = "",
         packages_file = "packages.yaml",
         lock_file = "packages.lock",
         mirror = "https://snapshot.debian.org",
@@ -52,10 +52,12 @@ def debian_packages_lockfile(
 
     data = [
         lockfile_generator,
-        snapshots_file,
         packages_file,
         lock_file,
     ]
+
+    if snapshots_file:
+        data.append(snapshots_file)
 
     args = [
         "$(location {})".format(lockfile_generator),

--- a/debian_packages/private/lockfile_generator/__main__.py
+++ b/debian_packages/private/lockfile_generator/__main__.py
@@ -22,7 +22,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--packages-file", type=Path, required=True)
     parser.add_argument("--lock-file", type=Path, required=True)
-    parser.add_argument("--snapshots-file", type=Path, default="")
+    parser.add_argument("--snapshots-file", type=str, default="")
     parser.add_argument("--update-snapshots-file", action="store_true", default=False)
     parser.add_argument("--mirror", type=str, default="https://snapshot.debian.org")
     parser.add_argument("--dry-run", action="store_true", default=False)
@@ -41,7 +41,7 @@ def main():
         logger.setLevel(logging.DEBUG)
 
     if args.snapshots_file:
-        snapshots = SnapshotsConfig.from_yaml_file(args.snapshots_file)
+        snapshots = SnapshotsConfig.from_yaml_file(Path(args.snapshots_file))
 
     logger.info(f"Using mirror: {args.mirror}")
 

--- a/debian_packages/private/lockfile_generator/deb.py
+++ b/debian_packages/private/lockfile_generator/deb.py
@@ -296,7 +296,7 @@ class PackageIndexGroup:
             arch=self.arch,
             distro=self.distro,
             pool_root_url=source,
-            index_file_path= ('/' if source[-1] != '/' else '') + f"binary-{self.debian_arch}/Packages.xz",
+            index_file_path= ('/' if source[-1] != '/' else '') + f"binary-{self.debian_arch}/Packages",
         )
 
     def resolve_package(

--- a/debian_packages/private/lockfile_generator/deb.py
+++ b/debian_packages/private/lockfile_generator/deb.py
@@ -296,7 +296,7 @@ class PackageIndexGroup:
             arch=self.arch,
             distro=self.distro,
             pool_root_url=source,
-            index_file_path= '' if source[-1] != '/' else '/' + f"binary-{self.debian_arch}/Packages.xz",
+            index_file_path= ('/' if source[-1] != '/' else '') + f"binary-{self.debian_arch}/Packages.xz",
         )
 
     def resolve_package(

--- a/debian_packages/private/lockfile_generator/deb.py
+++ b/debian_packages/private/lockfile_generator/deb.py
@@ -168,8 +168,8 @@ class PackageIndexGroup:
     distro: Distro
     mirror: str = None
     snapshots: SnapshotsConfig = None
-    exact_sources: list = field(init=False, default_factory=list)
-    indices: list = field(init=False, default_factory=list)
+    exact_sources: list[str] = field(init=False)
+    indices: list[str] = field(init=False)
     _packages: networkx.DiGraph = field(init=False, default_factory=networkx.DiGraph)
 
     def __post_init__(self):

--- a/debian_packages/private/lockfile_generator/deb.py
+++ b/debian_packages/private/lockfile_generator/deb.py
@@ -168,8 +168,8 @@ class PackageIndexGroup:
     arch: Arch
     distro: Distro
     mirror: str = None
-    exact_sources: list = []
-    indices: list = []
+    exact_sources: list = field(init=False, default_factory=list)
+    indices: list = field(init=False, default_factory=list)
     _packages: networkx.DiGraph = field(init=False, default_factory=networkx.DiGraph)
 
     def __post_init__(self):

--- a/debian_packages/private/lockfile_generator/deb.py
+++ b/debian_packages/private/lockfile_generator/deb.py
@@ -134,8 +134,8 @@ class Package:
 @dataclass
 class PackageIndex:
     name: str
-    snapshot: str = ""
     arch: Arch
+    snapshot: str = ""
     distro: Distro = ""
     pool_root_url: str
     index_file_path: str

--- a/debian_packages/private/lockfile_generator/deb.py
+++ b/debian_packages/private/lockfile_generator/deb.py
@@ -135,10 +135,10 @@ class Package:
 class PackageIndex:
     name: str
     arch: Arch
-    snapshot: str = ""
-    distro: Distro = ""
     pool_root_url: str
     index_file_path: str
+    snapshot: str = ""
+    distro: Distro = ""
     _packages: list[Package] = field(init=False, default_factory=list)
 
     @property

--- a/debian_packages/private/lockfile_generator/deb.py
+++ b/debian_packages/private/lockfile_generator/deb.py
@@ -168,8 +168,8 @@ class PackageIndexGroup:
     distro: Distro
     mirror: str = None
     snapshots: SnapshotsConfig = None
-    exact_sources: list[str] = field(init=False)
-    indices: list[str] = field(init=False)
+    exact_sources: list[str] = field(default_factory=list)
+    indices: list[str] = field(default_factory=list)
     _packages: networkx.DiGraph = field(init=False, default_factory=networkx.DiGraph)
 
     def __post_init__(self):

--- a/debian_packages/private/lockfile_generator/deb.py
+++ b/debian_packages/private/lockfile_generator/deb.py
@@ -164,10 +164,10 @@ class PackageIndex:
 
 @dataclass
 class PackageIndexGroup:
-    snapshots: SnapshotsConfig = None
     arch: Arch
     distro: Distro
     mirror: str = None
+    snapshots: SnapshotsConfig = None
     exact_sources: list = field(init=False, default_factory=list)
     indices: list = field(init=False, default_factory=list)
     _packages: networkx.DiGraph = field(init=False, default_factory=networkx.DiGraph)

--- a/debian_packages/private/lockfile_generator/lockfile.py
+++ b/debian_packages/private/lockfile_generator/lockfile.py
@@ -23,9 +23,10 @@ def _sanitize_name(name: str) -> str:
 
 
 def generate_lockfile(
-    snapshots_config: SnapshotsConfig,
-    packages_config: PackagesConfig,
-    mirror: str,
+    snapshots_config: SnapshotsConfig = None,
+    packages_config: PackagesConfig = None,
+    mirror: str = "",
+    exact_sources: list[str] = None,
 ) -> Lockfile:
     packages = defaultdict(lambda: defaultdict(list))
     files = defaultdict(lambda: defaultdict(list))
@@ -40,6 +41,7 @@ def generate_lockfile(
                     distro=distro,
                     arch=arch,
                     mirror=mirror,
+                    exact_sources=exact_sources,
                 )
             pig = pigs[(distro, arch)]
             for package_name in pc.packages:

--- a/debian_packages/private/lockfile_generator/lockfile.py
+++ b/debian_packages/private/lockfile_generator/lockfile.py
@@ -26,7 +26,7 @@ def generate_lockfile(
     snapshots_config: SnapshotsConfig = None,
     packages_config: PackagesConfig = None,
     mirror: str = "",
-    exact_sources: list[str] = None,
+    exact_sources: list[str] = [],
 ) -> Lockfile:
     packages = defaultdict(lambda: defaultdict(list))
     files = defaultdict(lambda: defaultdict(list))


### PR DESCRIPTION
With Ubuntu configuration of this repo, I'm running into issues with being forced into one single mirror with 3 specific components. While this makes sense for Debian, it breaks multiple architectures for i.e. [archive.ubuntu.com](url) where only amd64/i386 packages are hosted. 

To be clear, this PR does not solve the multiple architecture breakage. There should ultimately be checks for whether a Packages.xz exists for a given source, which would allow for multiple source specification and multiple arch specification.

In addition to solving this problem, this exact_sources configuration enables custom sources to be added, as referenced in #45.

As a reminder, this is very much a WIP. The purpose of opening this PR is to understand whether the contributors of this project think it's a good idea to pursue and correspondingly edit.

As of the opening of this PR, the following works:

`debian_packages_lockfile(
    name = "ubuntu_packages_amd64",
    lock_file = "ubuntu-packages.lock",
    packages_file = "ubuntu-packages.yaml",
    exact_sources = ["http://archive.ubuntu.com/ubuntu/dists/jammy/main", "http://archive.ubuntu.com/ubuntu/dists/jammy/universe", ]
)

debian_packages_lockfile(
    name = "ubuntu_packages_arm64",
    lock_file = "ubuntu-packages-arm.lock",
    packages_file = "ubuntu-packages-arm.yaml",
    exact_sources = ["http://ports.ubuntu.com/ubuntu-ports/dists/jammy/main", "http://ports.ubuntu.com/ubuntu-ports/dists/jammy/universe"]
)`